### PR TITLE
Change ssh keys deployments order and remove missing plugins

### DIFF
--- a/data/role/jenkins.yaml
+++ b/data/role/jenkins.yaml
@@ -3,8 +3,10 @@ psick::base::linux_classes:
   jenkins: psick::jenkins
   jenkins_casc: psick::jenkins::jcasc
   profile_env: profile::profile
+  ssh: ''
 psick::profiles::linux_classes:
   jenkins: ''
+  ssh: 'psick::openssh'
 
 psick::jenkins::disable_setup_wizard: true
 psick::jenkins::admin_password: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEATCj81Q+gBL86HsVCimdXdmCKe0RRXeafKGBGi+b8IydtMPeUr9855alCTtcpUbIXNEvgOPL3ybsZ8mWGz9ZGn2zj4ux1077kkoKivvQ5dznQJGWMSeNXBVDH9aW0cACkHc3vvnMrO4lMyqREz7GkjZkZ8LWahAFG2ILjo2LUcHBY+PXyRAiOZXN1EFterGyiaRJ/x7KuXTPWaQgGo+rFH2z7agh+aUziZN3t4Gd/T8TxBIfOprIkehRXSQBZJflj7jrW9PpViBAJL7/MpVPjqxNHO4qWn1d7aNKIW479uj/D/Iu+pRhzcPiqlrgiaaZmsiPbIunpgX8zkrcUpPOfpjA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCUOns1dg770kVgz3Jm7XNPgBATBR7F1nDiE0oIJgW1NzN0]
@@ -109,10 +111,6 @@ psick::jenkins::plugins:
   pipeline-utility-steps:
     enable: true
   s3:
-    enable: true
-  tasks-plugin:
-    enable: true
-  timestamps:
     enable: true
   warnings:
     enable: true


### PR DESCRIPTION
This commit changes ssh keys creation order. Now it is after jenkins
installation.
Also this commits remove jenkins plugin installation for plugins which do not exist (tasks-plugin, timestamps).
