### PR TITLE
Add suggested plugins for default installation to jenkins.yaml.

### DIFF
--- a/data/role/jenkins.yaml
+++ b/data/role/jenkins.yaml
@@ -119,3 +119,21 @@ psick::jenkins::plugins:
   xunit:
     enable: true
 
+  # Suggested plugins
+  build-timeout:
+    enable: true
+  credentials-binding:
+    enable: true
+  timestamper:
+    enable: true
+  ws-cleanup:
+    enable: true
+  pipeline-stage-view:
+    enable: true
+  git:
+    enable: true
+  matrix-auth:
+    enable: true
+  mailer:
+    enable: true
+


### PR DESCRIPTION
This commit adds to jenkins.yaml default suggested plugins instead using setup wizard. 
List of suggested plugins - https://github.com/jenkinsci/jenkins/blob/jenkins-2.19.4/core/src/main/resources/jenkins/install/platform-plugins.json