### PR TITLE
Changed psick::time::ntpdate to ntp daemon

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -136,7 +136,7 @@ psick::repo::add_defaults: true
 # Time settings
 psick::time::servers:
   - pool.ntp.org
-psick::time::ntpdate::crontab: "*/5 * * * *"
+psick::time::method: ntp
 
 # Timezone settings
 psick::timezone: UTC


### PR DESCRIPTION
This commit related to https://github.com/graduway/psick/issues/24
changed:      data/common.yaml