### PR TITLE
Do not install openssh by PSICK on web server

### DIFF
--- a/data/role/web.yaml
+++ b/data/role/web.yaml
@@ -8,6 +8,8 @@ psick::pre::windows_classes:
   webserver: psick::iis
   chocolatey: ''
 
+psick::openssh::tp::manage: false
+
 psick::iis::features:
   'Web-WebServer':
     ensure: present
@@ -26,6 +28,7 @@ psick::packages::packages_list:
   - "urlrewrite"
   - "webdeploy"
   - "zip"
+  - "openssh"
 
 psick::windows::features::install:
   'web-mgmt-tools':


### PR DESCRIPTION
This commit removes openssh installation by PSICK because PSICK
tries to install unix openssh but web server is windows.
Same we did for jenkins slave (https://github.com/graduway/psick-hieradata/commit/00fbe1be4dbea10ea11c63ba2d1ffc86e6244fea)
