### PR TITLE
Enforce to use env_prefix variable for openvpn server

### DIFF
--- a/data/role/openvpn.yaml
+++ b/data/role/openvpn.yaml
@@ -43,10 +43,10 @@ openvpn::server_defaults:
 
 openvpn::client_defaults:
   server: 'graduway-vpn'
-  remote_host: "vpn.%{::env_region}.graduway.com"
+  remote_host: "vpn.%{::env_prefix}.graduway.com"
   mail_from: "noreply@graduway.com"
   mail_domain: "graduway.com"
-  environment: "%{::env_region}"
+  environment: "%{::env_prefix}"
 openvpn::clients:
   'adi.efrat': {}
   'amir.algazi': {}
@@ -67,7 +67,7 @@ openvpn::clients:
 
 postfix::main_config:
   myorigin: '$mydomain'
-  myhostname: "vpn.%{::env_region}.graduway.com"
+  myhostname: "vpn.%{::env_prefix}.graduway.com"
   mydomain: "graduway.com"
   append_dot_mydomain: "no"
   smtp_sasl_auth_enable: "yes"


### PR DESCRIPTION
This commit changes openvpn configuration to use env_prefix.

Previously we had {env}.{region} in env_region variable.
Now we have {env}.{region} in env_prefix and {region} in env_region.

Initial change: https://github.com/graduway/ec2tagfacts/pull/10
Same we did here: https://github.com/graduway/psick-hieradata/pull/21