### PR TITLE
Set SLAVE_AAPT_TIMEOUT env variable on jenkins slave

### DIFF
--- a/data/role/jenkins-slave.yaml
+++ b/data/role/jenkins-slave.yaml
@@ -208,3 +208,7 @@ psick::windows::envs::envs_hash:
     value: "%{::facts.ec2_tag_role}"
     mergemode: clobber
     user: 'Administrator'
+  'SLAVE_AAPT_TIMEOUT':
+    value: "30"
+    mergemode: clobber
+    user: 'Administrator'


### PR DESCRIPTION
This commit sets SLAVE_AAPT_TIMEOUT=30 env var on jenkins slave
in order to fix "Timed out while waiting for slave aapt process"
periodic problem.