### PR TITLE
Add andorid SDK 29

### DIFF
--- a/data/role/jenkins-slave-ubuntu.yaml
+++ b/data/role/jenkins-slave-ubuntu.yaml
@@ -29,9 +29,11 @@ profile::android::android_sdk_tools:
   - "build-tools;26.0.0"
   - "build-tools;26.0.2"
   - "build-tools;28.0.3"
+  - "build-tools;29.0.2"
   - "platforms;android-26"
   - "platforms;android-27"
   - "platforms;android-28"
+  - "platforms;android-29"
 psick::openssh::configs_hash:
   jenkins-config:
     create_ssh_dir: true


### PR DESCRIPTION
This commit adds installation of Androind build tools 29 version on
jenkins slave